### PR TITLE
Fix missing LOCK TABLES in down! migrations

### DIFF
--- a/lib/table_migrator/copy_engine.rb
+++ b/lib/table_migrator/copy_engine.rb
@@ -63,6 +63,7 @@ module TableMigrator
     def down!
       in_table_lock(table_name, old_table_name) do
         execute("ALTER TABLE `#{table_name}` RENAME TO `#{new_table_name}`")
+        execute("LOCK TABLES `#{new_table_name}` WRITE")
         execute("ALTER TABLE `#{old_table_name}` RENAME TO `#{table_name}`")
         execute("DROP TABLE `#{new_table_name}`")
       end


### PR DESCRIPTION
After renaming table, lock is no longer valid as table does not exist. One must lock on the new table name to be allowed to drop the table.
