### PR TITLE
do not hardcode ActiveRecord version to 5.2 in migrations

### DIFF
--- a/lib/table_migration.rb
+++ b/lib/table_migration.rb
@@ -3,7 +3,7 @@ require 'table_migrator/base'
 
 migration_class =
   if ActiveRecord::VERSION::MAJOR >= 5
-    ActiveRecord::Migration[5.2]
+    ActiveRecord::Migration[ActiveRecord::VERSION::STRING.to_f]
   else
     ActiveRecord::Migration
   end

--- a/table_migrator.gemspec
+++ b/table_migrator.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "table_migrator"
-  s.version     = '0.1.2'
+  s.version     = '0.1.3'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Matt Freels", "Rohith Ravi", "Rick Olson",]
   s.email       = ["matt@freels.name"]


### PR DESCRIPTION
I was trying to upgrade Jigsaw from 5.0 to 5.1, but it got hung up on this line because the project doesn't have 5.2